### PR TITLE
Add base URL to Twitter Card and Open Graph images

### DIFF
--- a/src/Tags/OpenGraph.js
+++ b/src/Tags/OpenGraph.js
@@ -11,6 +11,9 @@ class OpenGraph extends BaseTag {
       scope.contexts[0].image = this.config.image;
     }
 
+    // Add base url from config to front matter image value
+    scope.contexts[0].image = this.config.url + scope.contexts[0].image;
+
     // Default `og:type` to article if none is set
     if (!scope.contexts[0].ogtype) {
       scope.contexts[0].ogtype = "article";
@@ -28,6 +31,9 @@ class OpenGraph extends BaseTag {
     if (!context.ctx.image && self.config.image) {
       context.ctx.image = self.config.image;
     }
+
+    // Add base url from config to front matter image value
+    context.ctx.image = self.config.url + context.ctx.image;
 
     // Default `og:type` to article if none is set
     if (!context.ctx.ogtype) {

--- a/src/Tags/TwitterCard.js
+++ b/src/Tags/TwitterCard.js
@@ -11,6 +11,9 @@ class TwitterCard extends BaseTag {
       scope.contexts[0].image = this.config.image;
     }
 
+    // Add base url from config to front matter image value
+    scope.contexts[0].image = this.config.url + scope.contexts[0].image;
+
     // Get twitter username for site from config.
     if (this.config.twitter) {
       scope.contexts[0].siteTwitter = this.config.twitter;
@@ -28,6 +31,9 @@ class TwitterCard extends BaseTag {
     if (!context.ctx.image && self.config.image) {
       context.ctx.image = self.config.image;
     }
+
+    // Add base url from config to front matter image value
+    context.ctx.image = self.config.url + context.ctx.image;
 
     // Get twitter username for site from config.
     if (self.config.twitter) {


### PR DESCRIPTION
It is a bit inflexible but immediately useful to make Twitter Card and Open Graph working with absolute images URLs (e.g. `/images/banner.png`) defined in the front matter. 