### PR TITLE
Add option to configure Twitter card type

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ eleventyConfig.addPlugin(pluginSEO, {
   options: {
     titleStyle: "minimalistic",
     titleDivider: "|",
-    imageWithBaseUrl: true
+    imageWithBaseUrl: true,
+    twitterCardType: "summary_large_image"
   }
 });
 ```  
@@ -145,6 +146,10 @@ Changes the divider between elements in the title output from `-` to any custom 
 #### imageWithBaseUrl
 
 Prepends the config `url` to the `image` option.
+
+#### twitterCardType
+
+Card type for Twitter card. Default is `summary`.
 
 ## Additional Tags
 

--- a/src/Tags/TwitterCard.js
+++ b/src/Tags/TwitterCard.js
@@ -26,7 +26,8 @@ class TwitterCard extends BaseTag {
     const templateContext = {
       ...scope.contexts[0],
       siteTwitter,
-      image: this.useImageWithBaseURL(this.config) ? baseImage : image
+      image: this.useImageWithBaseURL(this.config) ? baseImage : image,
+      cardType: this.config.options && this.config.options.twitterCardType || 'summary'
     };
 
     const source = this.loadTemplate("twittercard.liquid");
@@ -56,7 +57,8 @@ class TwitterCard extends BaseTag {
     const templateContext = {
       ...context.ctx,
       siteTwitter,
-      image: self.useImageWithBaseURL(self.config) ? baseImage : image
+      image: self.useImageWithBaseURL(self.config) ? baseImage : image,
+      cardType: self.config.options && self.config.options.twitterCardType || 'summary'
     };
 
     const template = self.loadTemplate("twittercard.njk");

--- a/src/templates/twittercard.liquid
+++ b/src/templates/twittercard.liquid
@@ -1,4 +1,4 @@
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="{{ cardType }}">
 {% if siteTwitter %}<meta name="twitter:site" content="@{{ siteTwitter }}">{% endif %}
 <meta name="twitter:url" content="{% canonicalURL %}">
 <meta name="twitter:title" content="{% pageTitle %}">

--- a/src/templates/twittercard.njk
+++ b/src/templates/twittercard.njk
@@ -1,4 +1,4 @@
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="{{ cardType }}">
 {% if siteTwitter %}<meta name="twitter:site" content="@{{ siteTwitter }}">{% endif %}
 <meta name="twitter:url" content="{% canonicalURL "" %}">
 <meta name="twitter:title" content="{% pageTitle "" %}">


### PR DESCRIPTION
Hi! I needed to set the type for the Twitter card to `summary_large_image` but `summary` was hardcoded. This PR adds an option in the config to specify the type.

Closes #20 