### PR TITLE
Check pagination size before adding pagination numbers

### DIFF
--- a/src/Tags/MetaRobots.js
+++ b/src/Tags/MetaRobots.js
@@ -1,10 +1,10 @@
 const BaseTag = require("./BaseTag");
 
 class MetaRobots extends BaseTag {
-  render(pageNumber) {
+  render(pageNumber, size) {
     let robots = "index,follow";
 
-    if (pageNumber > 0) {
+    if (pageNumber > 0 && size > 1) {
       robots = `no${robots}`;
     }
 
@@ -19,14 +19,24 @@ class MetaRobots extends BaseTag {
       0
     );
 
-    return Promise.resolve(this.render(pageNumber));
+    // Get page size from pagination.
+    const size = this.keyPathVal(
+      scope.contexts[0],
+      "pagination.size",
+      0
+    );
+
+    return Promise.resolve(this.render(pageNumber, size));
   }
 
   nunjucksRender(self, context) {
     // Get page number from pagination.
     const pageNumber = self.keyPathVal(context.ctx, "pagination.pageNumber", 0);
 
-    return self.render(pageNumber);
+    // Get page size from pagination.
+    const size = self.keyPathVal(context.ctx, "pagination.size", 0);
+
+    return self.render(pageNumber, size);
   }
 }
 

--- a/src/Tags/PageTitle.js
+++ b/src/Tags/PageTitle.js
@@ -1,7 +1,7 @@
 const BaseTag = require("./BaseTag");
 
 class PageTitle extends BaseTag {
-  render(title, pageNumber) {
+  render(title, pageNumber, size) {
     // Get options.
     const style = this.keyPathVal(this, "options.titleStyle", "default");
     const divider = this.keyPathVal(this, "options.titleDivider", "-");
@@ -10,7 +10,7 @@ class PageTitle extends BaseTag {
     let pageTitle = title || this.siteTitle;
 
     // Add pagination
-    if (pageNumber > 0) {
+    if (pageNumber > 0 && size > 1) {
       pageTitle = pageTitle + ` ${divider} Page ` + (pageNumber + 1);
     }
 
@@ -40,7 +40,14 @@ class PageTitle extends BaseTag {
       0
     );
 
-    return Promise.resolve(this.render(title, pageNumber));
+    // Get page size from pagination.
+    const size = this.keyPathVal(
+      scope.contexts[0],
+      "pagination.size",
+      0
+    );
+
+    return Promise.resolve(this.render(title, pageNumber, size));
   }
 
   nunjucksRender(self, context) {
@@ -54,7 +61,10 @@ class PageTitle extends BaseTag {
     // Get page number from pagination.
     const pageNumber = self.keyPathVal(context.ctx, "pagination.pageNumber", 0);
 
-    return self.render(title, pageNumber);
+    // Get page size from pagination.
+    const size = self.keyPathVal(context.ctx, "pagination.size", 0);
+
+    return self.render(title, pageNumber, size);
   }
 }
 

--- a/test/Tags/MetaRobotsTest.js
+++ b/test/Tags/MetaRobotsTest.js
@@ -10,9 +10,16 @@ test("Ordinary pages gets index and follow", t => {
 
 test("Paginated pages gets noindex and follow", t => {
   const metaRobots = new MetaRobots();
-  const robots = metaRobots.render(1);
+  const robots = metaRobots.render(1, 2);
 
   t.is(robots, "noindex,follow");
+});
+
+test("Paginated pages with size 1 gets index and follow", t => {
+  const metaRobots = new MetaRobots();
+  const robots = metaRobots.render(1, 1);
+
+  t.is(robots, "index,follow");
 });
 
 test("Missing pagination gets index and follow", t => {
@@ -27,7 +34,7 @@ test("Liquid engine should provide pagination for robots", t => {
   let scope = {
     contexts: [
       {
-        pagination: { pageNumber: 1 }
+        pagination: { pageNumber: 1, size: 2 }
       }
     ]
   };
@@ -43,7 +50,7 @@ test("Nunjucks engine should provide pagination for robots", t => {
   // Mock nunjucks engine context
   let context = {
     ctx: {
-      pagination: { pageNumber: 1 }
+      pagination: { pageNumber: 1, size: 2 }
     }
   };
 

--- a/test/Tags/PageTitleTest.js
+++ b/test/Tags/PageTitleTest.js
@@ -30,7 +30,7 @@ test("Title should be escaped", t => {
 
 test("Page and pagenumber should be added on paginated pages", t => {
   const pageTitle = new PageTitle(t.context.config);
-  let title = pageTitle.render("A title", 1);
+  let title = pageTitle.render("A title", 1, 2);
 
   t.is(title, "A title - Page 2 - Site title");
 });
@@ -38,6 +38,13 @@ test("Page and pagenumber should be added on paginated pages", t => {
 test("Page and pagenumber should not be added on paginated pages with pageNumber 0", t => {
   const pageTitle = new PageTitle(t.context.config);
   let title = pageTitle.render("A title", 0);
+
+  t.is(title, "A title - Site title");
+});
+
+test("Page and pagenumber should not be added on paginated pages with size 1", t => {
+  const pageTitle = new PageTitle(t.context.config);
+  let title = pageTitle.render("A title", 1, 1);
 
   t.is(title, "A title - Site title");
 });


### PR DESCRIPTION
There's a clever trick inside of Eleventy if you're wanting to create single views from an array of items, by using the pagination option and setting a `size` of `1`. The best example of this is within the Eleventy docs where it's used to [produce tag pages](https://www.11ty.dev/docs/quicktips/tag-pages/)

Prior to this change paginated pages would show a page number as well as apply a "noindex" meta value to the page. This is undesirable if you're using the aforementioned method to produce pages. This change checks if the `size` value is above `1` and then applies the page number and `noindex` value. I've tested this on a development project and added tests to the PR, which appear to be passing. Fixes #27

PS. Wasn't sure which branch to put this against, let me know if it's meant to be `master` instead of `develop` 👍🏻 