### PR TITLE
Support https images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-seo",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Eleventy plugin to generate meta tags for improved SEO.",
   "main": ".eleventy.js",
   "scripts": {

--- a/src/templates/opengraph.liquid
+++ b/src/templates/opengraph.liquid
@@ -2,4 +2,4 @@
 <meta property="og:type" content="{{ ogtype }}">
 <meta property="og:url" content="{% canonicalURL %}">
 <meta property="og:description" content="{% pageDescription %}">
-{% if image %}<meta property="og:image" content="{{ image }}">{% endif %}
+{% if image %}<meta property="og:image{% if image.indexOf("https://") === 0 %}:secure_url{% endif %}" content="{{ image }}">{% endif %}

--- a/src/templates/opengraph.njk
+++ b/src/templates/opengraph.njk
@@ -3,4 +3,4 @@
 {{ opengraph.type }}
 <meta property="og:url" content="{% canonicalURL "" %}">
 <meta property="og:description" content="{% pageDescription "" %}">
-{% if image %}<meta property="og:image" content="{{ image }}">{% endif %}
+{% if image %}<meta property="og:image{% if image.indexOf("https://") === 0 %}:secure_url{% endif %}" content="{{ image }}">{% endif %}


### PR DESCRIPTION
I ran into an issue where [Facebook sharing debugger](https://developers.facebook.com/tools/debug/) threw the error, "Provided og:image, https://<url> could not be downloaded" and I believe the reason is because the og:image meta tag [should instead be `og:image:secure_url`](https://stackoverflow.com/a/8858052). I added a conditional check for if the url starts with `https://`

I didn't change the twitter image tag because I couldn't find any documentation about secure urls.