### PR TITLE
Makes sure the `title` does not include HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "html-entities": "^1.2.1",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "jsdom": "^16.2.2"
   }
 }

--- a/src/Tags/PageTitle.js
+++ b/src/Tags/PageTitle.js
@@ -1,4 +1,5 @@
 const BaseTag = require("./BaseTag");
+const jsdom = require("jsdom");
 
 class PageTitle extends BaseTag {
   render(title, pageNumber, size) {
@@ -8,6 +9,10 @@ class PageTitle extends BaseTag {
 
     // Fallback on `title` in config if no title is set for the page.
     let pageTitle = title || this.siteTitle;
+    
+    // Strip any HTML in the title
+		const dom = new jsdom.JSDOM(`<!DOCTYPE html><h1>${pageTitle}</h1>`);
+    pageTitle = dom.window.document.querySelector("h1").textContent;
 
     // Showing page numbers?
     const showPages = this.showPageNumbers();


### PR DESCRIPTION
I chose to use JSDOM for it’s sophisticated level of DOM support, but am open to swapping it out for an alternative if that’s preferred. Not doing anything really fancy here, just trying to ensure there’s a DOM parser in play.

A lot of Eleventy plugins also use htmlparser2, so that might be a better solution. I tried to explore the core Eleventy packages for a built-in parser, but didn’t find any solid leads.