### PR TITLE
Add support for scope to be of type `Context` to fix rendering in Liquid

### DIFF
--- a/src/Tags/Canonical.js
+++ b/src/Tags/Canonical.js
@@ -20,7 +20,10 @@ class Canonical extends BaseTag {
     }
 
     // Use page data for URL if none was passed with argument.
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     url = url || context.page.url;
 
     return Promise.resolve(this.render(url));

--- a/src/Tags/Canonical.js
+++ b/src/Tags/Canonical.js
@@ -20,7 +20,8 @@ class Canonical extends BaseTag {
     }
 
     // Use page data for URL if none was passed with argument.
-    url = url || scope.contexts[0].page.url;
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    url = url || context.page.url;
 
     return Promise.resolve(this.render(url));
   }

--- a/src/Tags/MetaAuthor.js
+++ b/src/Tags/MetaAuthor.js
@@ -9,7 +9,10 @@ class MetaAuthor extends BaseTag {
   }
 
   liquidRender(scope, hash) {
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     // Get author from front matter.
     const author = context.author;
 

--- a/src/Tags/MetaAuthor.js
+++ b/src/Tags/MetaAuthor.js
@@ -9,8 +9,9 @@ class MetaAuthor extends BaseTag {
   }
 
   liquidRender(scope, hash) {
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
     // Get author from front matter.
-    const author = scope.contexts[0].author;
+    const author = context.author;
 
     return Promise.resolve(this.render(author));
   }

--- a/src/Tags/MetaRobots.js
+++ b/src/Tags/MetaRobots.js
@@ -12,14 +12,13 @@ class MetaRobots extends BaseTag {
   }
 
   liquidRender(scope, hash) {
-    const context = (typeof scope.contexts === "undefined") ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
 
     // Get page number from pagination.
-    const pageNumber = this.keyPathVal(
-      context,
-      "pagination.pageNumber",
-      0
-    );
+    const pageNumber = this.keyPathVal(context, "pagination.pageNumber", 0);
 
     // Get page size from pagination.
     const size = this.keyPathVal(context, "pagination.size", 0);

--- a/src/Tags/MetaRobots.js
+++ b/src/Tags/MetaRobots.js
@@ -12,15 +12,17 @@ class MetaRobots extends BaseTag {
   }
 
   liquidRender(scope, hash) {
+    const context = (typeof scope.contexts === "undefined") ? scope.environments : scope.contexts[0];
+
     // Get page number from pagination.
     const pageNumber = this.keyPathVal(
-      scope.contexts[0],
+      context,
       "pagination.pageNumber",
       0
     );
 
     // Get page size from pagination.
-    const size = this.keyPathVal(scope.contexts[0], "pagination.size", 0);
+    const size = this.keyPathVal(context, "pagination.size", 0);
 
     return Promise.resolve(this.render(pageNumber, size));
   }

--- a/src/Tags/OpenGraph.js
+++ b/src/Tags/OpenGraph.js
@@ -6,21 +6,20 @@ const BaseTag = require("./BaseTag");
  */
 class OpenGraph extends BaseTag {
   async liquidRender(scope, hash) {
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     // Fallback on using image in config if available and none is set in front matter.
     const hasConfigImageOnly = !context.image && this.config.image;
 
-    const image = hasConfigImageOnly
-      ? this.config.image
-      : context.image;
+    const image = hasConfigImageOnly ? this.config.image : context.image;
 
     // Add base url from config to front matter image value
     const baseImage = this.config.url + image;
 
     // Default `og:type` to article if none is set
-    const ogtype = !context.ogtype
-      ? "article"
-      : context.ogtype;
+    const ogtype = !context.ogtype ? "article" : context.ogtype;
 
     // Define and update a new template context
     const templateContext = {

--- a/src/Tags/OpenGraph.js
+++ b/src/Tags/OpenGraph.js
@@ -6,24 +6,25 @@ const BaseTag = require("./BaseTag");
  */
 class OpenGraph extends BaseTag {
   async liquidRender(scope, hash) {
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
     // Fallback on using image in config if available and none is set in front matter.
-    const hasConfigImageOnly = !scope.contexts[0].image && this.config.image;
+    const hasConfigImageOnly = !context.image && this.config.image;
 
     const image = hasConfigImageOnly
       ? this.config.image
-      : scope.contexts[0].image;
+      : context.image;
 
     // Add base url from config to front matter image value
     const baseImage = this.config.url + image;
 
     // Default `og:type` to article if none is set
-    const ogtype = !scope.contexts[0].ogtype
+    const ogtype = !context.ogtype
       ? "article"
-      : scope.contexts[0].ogtype;
+      : context.ogtype;
 
     // Define and update a new template context
     const templateContext = {
-      ...scope.contexts[0],
+      ...context,
       ogtype,
       image: this.useImageWithBaseURL(this.config) ? baseImage : image
     };

--- a/src/Tags/PageDescription.js
+++ b/src/Tags/PageDescription.js
@@ -9,8 +9,9 @@ class PageDescription extends BaseTag {
   }
 
   liquidRender(scope, hash) {
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
     // Get excerpt from front matter.
-    const excerpt = scope.contexts[0].excerpt;
+    const excerpt = context.excerpt;
 
     return Promise.resolve(this.render(excerpt));
   }

--- a/src/Tags/PageDescription.js
+++ b/src/Tags/PageDescription.js
@@ -9,7 +9,10 @@ class PageDescription extends BaseTag {
   }
 
   liquidRender(scope, hash) {
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     // Get excerpt from front matter.
     const excerpt = context.excerpt;
 

--- a/src/Tags/PageTitle.js
+++ b/src/Tags/PageTitle.js
@@ -29,7 +29,10 @@ class PageTitle extends BaseTag {
   }
 
   liquidRender(scope, hash) {
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     // Get title from front matter.
     const title =
       typeof context.renderData !== "undefined" &&
@@ -38,11 +41,7 @@ class PageTitle extends BaseTag {
         : context.title;
 
     // Get page number from pagination.
-    const pageNumber = this.keyPathVal(
-      context,
-      "pagination.pageNumber",
-      0
-    );
+    const pageNumber = this.keyPathVal(context, "pagination.pageNumber", 0);
 
     // Get page size from pagination.
     const size = this.keyPathVal(context, "pagination.size", 0);

--- a/src/Tags/PageTitle.js
+++ b/src/Tags/PageTitle.js
@@ -29,25 +29,26 @@ class PageTitle extends BaseTag {
   }
 
   liquidRender(scope, hash) {
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
     // Get title from front matter.
     const title =
-      typeof scope.contexts[0].renderData !== "undefined" &&
-      typeof scope.contexts[0].renderData.title !== "undefined"
-        ? scope.contexts[0].renderData.title
-        : scope.contexts[0].title;
+      typeof context.renderData !== "undefined" &&
+      typeof context.renderData.title !== "undefined"
+        ? context.renderData.title
+        : context.title;
 
     // Get page number from pagination.
     const pageNumber = this.keyPathVal(
-      scope.contexts[0],
+      context,
       "pagination.pageNumber",
       0
     );
 
     // Get page size from pagination.
-    const size = this.keyPathVal(scope.contexts[0], "pagination.size", 0);
+    const size = this.keyPathVal(context, "pagination.size", 0);
 
     // Showing page numbers?
-    const showPages = this.showPageNumbers(scope.contexts[0].renderData);
+    const showPages = this.showPageNumbers(context.renderData);
 
     return Promise.resolve(
       showPages

--- a/src/Tags/SEO.js
+++ b/src/Tags/SEO.js
@@ -4,7 +4,10 @@ class SEO extends BaseTag {
   async liquidRender(scope, hash) {
     const template = this.loadTemplate("seo.liquid");
     const parsed = this.engine.parse(template);
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     const rendered = await this.engine.render(parsed, context);
 
     return Promise.resolve(rendered);

--- a/src/Tags/SEO.js
+++ b/src/Tags/SEO.js
@@ -4,7 +4,8 @@ class SEO extends BaseTag {
   async liquidRender(scope, hash) {
     const template = this.loadTemplate("seo.liquid");
     const parsed = this.engine.parse(template);
-    const rendered = await this.engine.render(parsed, scope.contexts[0]);
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const rendered = await this.engine.render(parsed, context);
 
     return Promise.resolve(rendered);
   }

--- a/src/Tags/TwitterCard.js
+++ b/src/Tags/TwitterCard.js
@@ -6,25 +6,26 @@ const BaseTag = require("./BaseTag");
  */
 class TwitterCard extends BaseTag {
   async liquidRender(scope, hash) {
+    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
     // Fallback on using image in config if available and none is set in front matter.
-    const hasConfigImageOnly = !scope.contexts[0].image && this.config.image;
+    const hasConfigImageOnly = !context.image && this.config.image;
 
     const image = hasConfigImageOnly
       ? this.config.image
-      : scope.contexts[0].image;
+      : context.image;
 
     // Add base url from config to front matter image value
     const baseImage = this.config.url + image;
 
     // Get twitter username for site from config.
     const siteTwitter =
-      !scope.contexts[0].siteTwitter && this.config.twitter
+      !context.siteTwitter && this.config.twitter
         ? this.config.twitter
-        : scope.contexts[0].siteTwitter;
+        : context.siteTwitter;
 
     // Define and update a new template context
     const templateContext = {
-      ...scope.contexts[0],
+      ...context,
       siteTwitter,
       image: this.useImageWithBaseURL(this.config) ? baseImage : image,
       cardType: this.keyPathVal(this, "options.twitterCardType")

--- a/src/Tags/TwitterCard.js
+++ b/src/Tags/TwitterCard.js
@@ -6,13 +6,14 @@ const BaseTag = require("./BaseTag");
  */
 class TwitterCard extends BaseTag {
   async liquidRender(scope, hash) {
-    const context = typeof scope.contexts === "undefined" ? scope.environments : scope.contexts[0];
+    const context =
+      typeof scope.contexts === "undefined"
+        ? scope.environments
+        : scope.contexts[0];
     // Fallback on using image in config if available and none is set in front matter.
     const hasConfigImageOnly = !context.image && this.config.image;
 
-    const image = hasConfigImageOnly
-      ? this.config.image
-      : context.image;
+    const image = hasConfigImageOnly ? this.config.image : context.image;
 
     // Add base url from config to front matter image value
     const baseImage = this.config.url + image;

--- a/test/Tags/CanonicalTest.js
+++ b/test/Tags/CanonicalTest.js
@@ -39,6 +39,26 @@ test("liquid: canonical url from page url", t => {
   });
 });
 
+test("liquid: canonical url from page url when scope is of type Context", t => {
+  t.context.scope = {
+    environments: {
+      page: {
+        url: "/foo"
+      }
+    }
+  };
+
+  const config = new Config({ url: "https://test.com" });
+  const canonical = new Canonical(config, null);
+  const object = canonical.getLiquidTag();
+
+  object.parse({ args: "" });
+
+  return object.render(t.context.scope).then(result => {
+    t.is(result, "https://test.com/foo");
+  });
+});
+
 test("nunjucks: canonical url from page url", t => {
   const config = new Config({ url: "https://test.com" });
   const canonical = new Canonical(config);

--- a/test/Tags/MetaAuthorTest.js
+++ b/test/Tags/MetaAuthorTest.js
@@ -41,10 +41,9 @@ test("Liquid engine should provide author", t => {
 test("Liquid engine should provide author when scope is of type Context", t => {
   // Mock liquid engine scope
   let scope = {
-    environments:
-      {
-        author: "an author"
-      }
+    environments: {
+      author: "an author"
+    }
   };
 
   const metaAuthor = new MetaAuthor(t.context.config);

--- a/test/Tags/MetaAuthorTest.js
+++ b/test/Tags/MetaAuthorTest.js
@@ -38,6 +38,22 @@ test("Liquid engine should provide author", t => {
   });
 });
 
+test("Liquid engine should provide author when scope is of type Context", t => {
+  // Mock liquid engine scope
+  let scope = {
+    environments:
+      {
+        author: "an author"
+      }
+  };
+
+  const metaAuthor = new MetaAuthor(t.context.config);
+
+  return metaAuthor.liquidRender(scope).then(result => {
+    t.is(result, "an author");
+  });
+});
+
 test("Nunjucks engine should provide author", t => {
   // Mock nunjucks engine context
   let context = {

--- a/test/Tags/MetaRobotsTest.js
+++ b/test/Tags/MetaRobotsTest.js
@@ -46,6 +46,22 @@ test("Liquid engine should provide pagination for robots", t => {
   });
 });
 
+test("Liquid engine should provide pagination for robots when scope is of type Context", t => {
+  // Mock liquid engine scope
+  let scope = {
+    environments:
+      {
+        pagination: { pageNumber: 1, size: 2 }
+      }
+  };
+
+  const metaRobots = new MetaRobots();
+
+  return metaRobots.liquidRender(scope).then(result => {
+    t.is(result, "noindex,follow");
+  });
+});
+
 test("Nunjucks engine should provide pagination for robots", t => {
   // Mock nunjucks engine context
   let context = {

--- a/test/Tags/MetaRobotsTest.js
+++ b/test/Tags/MetaRobotsTest.js
@@ -49,10 +49,9 @@ test("Liquid engine should provide pagination for robots", t => {
 test("Liquid engine should provide pagination for robots when scope is of type Context", t => {
   // Mock liquid engine scope
   let scope = {
-    environments:
-      {
-        pagination: { pageNumber: 1, size: 2 }
-      }
+    environments: {
+      pagination: { pageNumber: 1, size: 2 }
+    }
   };
 
   const metaRobots = new MetaRobots();

--- a/test/Tags/OpenGraphTest.js
+++ b/test/Tags/OpenGraphTest.js
@@ -50,6 +50,31 @@ test("liquid: generates open graph markup", t => {
   });
 });
 
+test("liquid: generates open graph markup when scope is of type Context", t => {
+  t.context.scope = {
+    environments: {}
+  };
+  // Mock liquidEngine
+  const liquidEngine = {
+    parse(template) {
+      return template;
+    },
+    render(template, contexts) {
+      return new Promise(resolve => {
+        resolve(template);
+      });
+    }
+  };
+
+  const config = new Config();
+  const openGraph = new OpenGraph(config, t.context.liquidEngineMock);
+  const object = openGraph.getLiquidTag();
+
+  return object.render(t.context.scope).then(result => {
+    t.truthy(result.template.includes(`og:type`));
+  });
+});
+
 test("nunjucks: generates open graph markup", t => {
   const config = new Config();
   const openGraph = new OpenGraph(config);

--- a/test/Tags/PageDescriptionTest.js
+++ b/test/Tags/PageDescriptionTest.js
@@ -52,6 +52,22 @@ test("Liquid engine should provide front matter excerpt", t => {
   });
 });
 
+test("Liquid engine should provide front matter excerpt when scope is of type Context", t => {
+  // Mock liquid engine scope
+  let scope = {
+    environments:
+      {
+        excerpt: "Excerpt in front matter"
+      }
+  };
+
+  const pageDescription = new PageDescription();
+
+  return pageDescription.liquidRender(scope).then(result => {
+    t.is(result, "Excerpt in front matter");
+  });
+});
+
 test("Nunjucks engine should provide front matter excerpt", t => {
   // Mock nunjucks engine context
   let context = {

--- a/test/Tags/PageDescriptionTest.js
+++ b/test/Tags/PageDescriptionTest.js
@@ -55,10 +55,9 @@ test("Liquid engine should provide front matter excerpt", t => {
 test("Liquid engine should provide front matter excerpt when scope is of type Context", t => {
   // Mock liquid engine scope
   let scope = {
-    environments:
-      {
-        excerpt: "Excerpt in front matter"
-      }
+    environments: {
+      excerpt: "Excerpt in front matter"
+    }
   };
 
   const pageDescription = new PageDescription();

--- a/test/Tags/PageTitleTest.js
+++ b/test/Tags/PageTitleTest.js
@@ -99,6 +99,22 @@ test("Liquid engine should provide front matter title", t => {
   });
 });
 
+test("Liquid engine should provide front matter title when scope is of type Context", t => {
+  // Mock liquid engine scope
+  let scope = {
+    environments:
+      {
+        title: "Front matter title"
+      }
+  };
+
+  const pageTitle = new PageTitle(t.context.config);
+
+  return pageTitle.liquidRender(scope).then(result => {
+    t.is(result, "Front matter title - Site title");
+  });
+});
+
 test("Liquid engine should use computed title", t => {
   // Mock liquid engine scope
   let scope = {

--- a/test/Tags/PageTitleTest.js
+++ b/test/Tags/PageTitleTest.js
@@ -102,10 +102,9 @@ test("Liquid engine should provide front matter title", t => {
 test("Liquid engine should provide front matter title when scope is of type Context", t => {
   // Mock liquid engine scope
   let scope = {
-    environments:
-      {
-        title: "Front matter title"
-      }
+    environments: {
+      title: "Front matter title"
+    }
   };
 
   const pageTitle = new PageTitle(t.context.config);

--- a/test/Tags/SEOTest.js
+++ b/test/Tags/SEOTest.js
@@ -40,6 +40,40 @@ test("SEO renders liquid template", t => {
   });
 });
 
+test("SEO renders liquid template when scope is of type Context", t => {
+  t.context.scope = {
+    environments:
+      {
+        page: {
+          url: "/foo"
+        }
+      }
+  };
+  // Mock LiquidEngine.
+  const liquidEngine = {
+    parse(template) {
+      return template;
+    },
+    render(template, contexts) {
+      return new Promise(resolve => {
+        resolve(template);
+      });
+    }
+  };
+
+  const config = new Config({ url: "https://test.com" });
+  const seo = new SEO(config, liquidEngine);
+  const object = seo.getLiquidTag();
+
+  object.parse();
+
+  return object.render(t.context.scope).then(result => {
+    t.truthy(
+      result.includes(`<link rel="canonical" href="{% canonicalURL %}">`)
+    );
+  });
+});
+
 test("SEO renders nunjucks template", t => {
   // Mock nunjucks context
   let contextMock = {

--- a/test/Tags/SEOTest.js
+++ b/test/Tags/SEOTest.js
@@ -42,12 +42,11 @@ test("SEO renders liquid template", t => {
 
 test("SEO renders liquid template when scope is of type Context", t => {
   t.context.scope = {
-    environments:
-      {
-        page: {
-          url: "/foo"
-        }
+    environments: {
+      page: {
+        url: "/foo"
       }
+    }
   };
   // Mock LiquidEngine.
   const liquidEngine = {

--- a/test/Tags/TwitterCardTest.js
+++ b/test/Tags/TwitterCardTest.js
@@ -38,6 +38,19 @@ test("liquid: page without image falls back on config image", t => {
   });
 });
 
+test("liquid: page without image falls back on config image when scope is of type Context", t => {
+  t.context.scope = {
+    environments: {}
+  };
+  const config = new Config({ image: "foo.jpg" });
+  const twitterCard = new TwitterCard(config, t.context.liquidEngineMock);
+  const object = twitterCard.getLiquidTag();
+
+  return object.render(t.context.scope).then(result => {
+    t.is(result.contexts.image, "foo.jpg");
+  });
+});
+
 test("nunjucks: page without image falls back on config image", t => {
   const config = new Config({ image: "foo.jpg" });
   const twitterCard = new TwitterCard(config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR attempts to add support for the `scope` variable when it is of type [Context](https://github.com/harttle/liquidjs/blob/master/src/context/context.ts). Without these changes, I was unable to use this plugin to generate SEO tags for my Eleventy site which uses Liquid templates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempting to use this plugin on an Eleventy site with Liquid templates resulted in runtime errors (snapshot below). It seems like other people have also [run into this issue](https://nicolashery.com/moving-a-blog-from-jekyll-to-eleventy/) when attempting to use this plugin. 
```
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] 1. Having trouble writing to "_site/contact/index.html" from "./src/pages/contact.md" (via EleventyTemplateError)
[11ty] 2. Cannot read property '0' of undefined, line:9, col:1 (via RenderError)
[11ty] 3. Cannot read property '0' of undefined (via TypeError)
[11ty] 
[11ty] Original error stack trace: TypeError: Cannot read property '0' of undefined
[11ty]     at OpenGraph.liquidRender (/Users/gracexu/Projects/digital-services-coalition/node_modules/eleventy-plugin-seo/src/Tags/OpenGraph.js:10:47)
[11ty]     at Object.render (/Users/gracexu/Projects/digital-services-coalition/node_modules/eleventy-plugin-seo/src/Tags/BaseTag.js:41:37)
[11ty]     at Object.render (/Users/gracexu/Projects/digital-services-coalition/node_modules/liquidjs/dist/liquid.node.cjs.js:2023:41)
[11ty]     at render.next (<anonymous>)
[11ty]     at toPromise (/Users/gracexu/Projects/digital-services-coalition/node_modules/liquidjs/dist/liquid.node.cjs.js:462:32)
[11ty]     at async toPromise (/Users/gracexu/Projects/digital-services-coalition/node_modules/liquidjs/dist/liquid.node.cjs.js:470:25)
[11ty]     at async SEO.liquidRender (/Users/gracexu/Projects/digital-services-coalition/node_modules/eleventy-plugin-seo/src/Tags/SEO.js:7:22)
[11ty]     at async toPromise (/Users/gracexu/Projects/digital-services-coalition/node_modules/liquidjs/dist/liquid.node.cjs.js:470:25)
[11ty]     at async toPromise (/Users/gracexu/Projects/digital-services-coalition/node_modules/liquidjs/dist/liquid.node.cjs.js:470:25)
[11ty]     at async TemplateLayout.render (/Users/gracexu/Projects/digital-services-coalition/node_modules/@11ty/eleventy/src/TemplateLayout.js:236:25)
```
After some digging, I realized that the error was coming from the references to `scope.contexts[0]` in the liquidRender functions. Printing `scope` to the console revealed that the object didn't have a field called `contexts`, hence the "Cannot read property '0' of undefined" error. 


<details>
  <summary>Click to see a snapshot of what the `scope` object looked like on my local</summary>
```
Context {
  scopes: [ {} ],
  registers: {},
  sync: false,
  opts: {
    root: [ 'src/_includes', 'src' ],
    layouts: [ 'src/_includes', 'src' ],
    partials: [ 'src/_includes', 'src' ],
    relativeReference: true,
    jekyllInclude: false,
    cache: undefined,
    extname: '.liquid',
    fs: [Object: null prototype] {
      exists: [AsyncFunction: exists],
      readFile: [Function: readFile],
      existsSync: [Function: existsSync],
      readFileSync: [Function: readFileSync],
      resolve: [Function: resolve],
      fallback: [Function: fallback],
      dirname: [Function: dirname],
      contains: [Function: contains],
      sep: '/'
    },
    dynamicPartials: true,
    jsTruthy: false,
    dateFormat: '%A, %B %-e, %Y at %-l:%M %P %z',
    trimTagRight: false,
    trimTagLeft: false,
    trimOutputRight: false,
    trimOutputLeft: false,
    greedy: true,
    tagDelimiterLeft: '{%',
    tagDelimiterRight: '%}',
    outputDelimiterLeft: '{{',
    outputDelimiterRight: '}}',
    preserveTimezones: false,
    strictFilters: true,
    strictVariables: false,
    ownPropertyOnly: true,
    lenientIf: false,
    globals: {},
    keepOutputType: false,
    operators: {
      '==': [Function: equal],
      '!=': [Function: !=],
      '>': [Function: >],
      '<': [Function: <],
      '>=': [Function: >=],
      '<=': [Function: <=],
      contains: [Function: contains],
      not: [Function: not],
      and: [Function: and],
      or: [Function: or]
    },
    outputEscape: undefined
  },
  globals: {},
  environments: {
    eleventy: { version: '2.0.1', generator: 'Eleventy v2.0.1', env: [Object] },
    pkg: {
      name: 'digital-services-coalition',
      version: '1.0.0',
      description: '',
      main: 'index.js',
      scripts: [Object],
      repository: [Object],
      keywords: [],
      author: '',
      license: 'ISC',
      bugs: [Object],
      homepage: 'https://github.com/DSCoalition/dsc-11ty-cms',
      devDependencies: [Object],
      dependencies: [Object]
    },
    title: 'Story',
    layout: 'layouts/story.liquid',
    permalink: '/story/',
    heroTitle: 'Answering the call by building a community.',
    eleventyNavigation: { key: 'Story', order: 3 },
    page: {
      date: 2023-08-28T16:46:58.708Z,
      inputPath: './src/pages/story.md',
      fileSlug: 'story',
      filePathStem: '/pages/story',
      outputFileExtension: 'html',
      templateSyntax: 'liquid,md',
      url: '/story/',
      outputPath: '_site/story/index.html'
    },
    collections: { all: [Array], boardMemberItem: [Array], orgItem: [Array] },
    content: '\n' +
      '<section>\n' +
      '</section>'
  },
  strictVariables: false,
  ownPropertyOnly: true
}
``` 
</details>

I checked the LiquidJS changelog and it does look like [a recent change](https://github.com/harttle/liquidjs/compare/v10.3.2...v10.3.3) was made in 2022 to support scopes of type `Context`.

To maintain backwards compatibility while fixing the issue I just added a check to set the context to `scope.environments `(the user passed in scope for the Context type) when `scope.contexts` is undefined.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added some tests for the new use case and made sure all tests passed. I confirmed that after making these changes I was able to generate SEO tags and use this plugin on my Eleventy site.
![Screen Shot 2023-10-19 at 5 51 45 PM](https://github.com/artstorm/eleventy-plugin-seo/assets/5403975/e0870084-c890-4068-927e-0aac9f12c69d)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
~~- [ ] New feature (non-breaking change that adds functionality)~~
~~- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
~~- [ ] My change requires a change to the documentation.~~
~~- [ ] I have updated the documentation accordingly.~~

Thanks for your work creating and maintaining this plugin! 😄 